### PR TITLE
Update lh-user-taxonomies.php

### DIFF
--- a/lh-user-taxonomies.php
+++ b/lh-user-taxonomies.php
@@ -66,7 +66,7 @@ class LH_User_Taxonomies_plugin {
 		global $wp_taxonomies;
 		
 		// Only modify user taxonomies, everything else can stay as is
-		if($object != 'user') return;
+		if (((!is_array($object)) && ($object != 'user')) || (!in_array('user', $object))) return;
 		
 		// We're given an array, but expected to work with an object later on
 		$args	= (object) $args;


### PR DESCRIPTION
I made a small modification to the code to allow the same taxonomy to be registered to users and other post types at the same time.
In the [WordPress function reference for registering taxonomies](https://codex.wordpress.org/Function_Reference/register_taxonomy), the object_type can either be a string or array.
Your previous code only allowed a single string of users, so I modified to code to detect if it is an array and check for the string 'user' in the array.
