### PR TITLE
Reinstate permissions check before outputting edit controls

### DIFF
--- a/lh-user-taxonomies.php
+++ b/lh-user-taxonomies.php
@@ -207,7 +207,7 @@ class LH_User_Taxonomies_plugin {
 		
 		foreach(self::$taxonomies as $key=>$taxonomy):
 			// Check the current user can assign terms for this taxonomy
-			//if(!current_user_can($taxonomy->cap->assign_terms)) continue;
+			if(!current_user_can($taxonomy->cap->assign_terms)) continue;
 			// Get all the terms in this taxonomy
 			$terms		= get_terms($key, array('hide_empty'=>false));
 			$stack 		= wp_list_pluck( wp_get_object_terms( $user->ID, $key ), 'slug' );


### PR DESCRIPTION
The permissions check before outputting the taxonomy checkboxes in the edit-user screen was commented out. Was this just an error? I see that the user can't edit their own terms unless they have the correct permissions, but IMHO either they shouldn't see them or they should get a message explaining why the controls that they have been presented with do nothing.